### PR TITLE
Provide implicit wrapper for reading OWL files.

### DIFF
--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/dataset/FunctionalSyntaxOWLExpressionsDatasetBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/dataset/FunctionalSyntaxOWLExpressionsDatasetBuilder.scala
@@ -6,8 +6,8 @@ import org.apache.spark.sql.SparkSession
 
 object FunctionalSyntaxOWLExpressionsDatasetBuilder {
   def build(spark: SparkSession, filePath: String): OWLExpressionsDataset = {
-    val rdd = FunctionalSyntaxOWLExpressionsRDDBuilder.build(spark.sparkContext, filePath)
+    val rdd = FunctionalSyntaxOWLExpressionsRDDBuilder.build(spark, filePath)
     import spark.implicits._
-    spark.sqlContext.createDataset[String](rdd)
+    spark.createDataset[String](rdd)
   }
 }

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/dataset/ManchesterSyntaxOWLExpressionsDatasetBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/dataset/ManchesterSyntaxOWLExpressionsDatasetBuilder.scala
@@ -1,9 +1,8 @@
 package net.sansa_stack.owl.spark.dataset
 
-import net.sansa_stack.owl.common.parsing.{ManchesterSyntaxParsing, ManchesterSyntaxPrefixParsing}
+import net.sansa_stack.owl.common.parsing.{ ManchesterSyntaxParsing, ManchesterSyntaxPrefixParsing }
 import net.sansa_stack.owl.spark.rdd.ManchesterSyntaxOWLExpressionsRDDBuilder
 import org.apache.spark.sql.SparkSession
-
 
 object ManchesterSyntaxOWLExpressionsDatasetBuilder extends ManchesterSyntaxPrefixParsing {
   def build(spark: SparkSession, filePath: String): OWLExpressionsDataset = {
@@ -12,11 +11,11 @@ object ManchesterSyntaxOWLExpressionsDatasetBuilder extends ManchesterSyntaxPref
 
   private[dataset] def buildAndGetDefaultPrefix(spark: SparkSession, filePath: String): (OWLExpressionsDataset, String) = {
     val res =
-      ManchesterSyntaxOWLExpressionsRDDBuilder.buildAndGetPrefixes(spark.sparkContext, filePath)
+      ManchesterSyntaxOWLExpressionsRDDBuilder.buildAndGetPrefixes(spark, filePath)
     val rdd = res._1
     val defaultPrefix = res._2.getOrElse(ManchesterSyntaxParsing._empty, ManchesterSyntaxParsing.dummyURI)
 
     import spark.implicits._
-    (spark.sqlContext.createDataset[String](rdd), defaultPrefix)
+    (spark.createDataset[String](rdd), defaultPrefix)
   }
 }

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/package.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/package.scala
@@ -1,0 +1,87 @@
+package net.sansa_stack.owl.spark
+
+import org.apache.spark.sql.Dataset
+import org.semanticweb.owlapi.model.OWLAxiom
+import net.sansa_stack.owl.spark.rdd._
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.rdd.RDD
+
+/**
+ * Wrap up implicit classes/methods to read OWL data into either [[Dataset]] or
+ * [[RDD]].
+ * 
+ * @author Gezim Sejdiu
+ */
+
+package object owl {
+
+  object Syntax extends Enumeration {
+    val FUNCTIONAL, MANCHESTER, OWLXML = Value
+  }
+
+  /**
+   * Adds methods, `owl(syntax: Syntax)`, `functional` and `manchester`, to [[SparkSession]] that allows to read owl files.
+   */
+  implicit class OWLAxiomReader(spark: SparkSession) {
+
+    /**
+     * Load RDF data into a `RDD[OWLAxiom]. Currently, only functional and manchester syntax are supported
+     * @param syntax of the OWL (functional or manchester)
+     * @return a [[OWLAxiomsRDD]]
+     */
+    def owl(syntax: Syntax.Value): String => OWLAxiomsRDD = syntax match {
+      case Syntax.FUNCTIONAL => functional
+      case Syntax.MANCHESTER => manchester
+      case _                 => throw new IllegalArgumentException(s"${syntax} syntax not supported yet!")
+    }
+
+    /**
+     * Load OWL data in Functional syntax into an [[RDD]][OWLAxiom].
+     * @return the [[OWLAxiomsRDD]]
+     */
+    def functional: String => OWLAxiomsRDD = path => {
+      FunctionalSyntaxOWLAxiomsRDDBuilder.build(spark, path)
+    }
+
+    /**
+     * Load OWL data in Manchester syntax into an [[RDD]][OWLAxiom].
+     * @return the [[OWLAxiomsRDD]]
+     */
+    def manchester: String => OWLAxiomsRDD = path => {
+      ManchesterSyntaxOWLAxiomsRDDBuilder.build(spark, path)
+    }
+
+  }
+
+  implicit class OWLExpressionsRDDReader(spark: SparkSession) {
+
+  /**
+     * Load RDF data into a `RDD[String]. Currently, only functional and manchester syntax are supported
+     * @param syntax of the OWL (functional or manchester)
+     * @return a [[OWLExpressionsRDD]]
+     */
+    def owlExpressions(syntax: Syntax.Value): String => OWLExpressionsRDD = syntax match {
+      case Syntax.FUNCTIONAL => functional
+      case Syntax.MANCHESTER => manchester
+      case _                 => throw new IllegalArgumentException(s"${syntax} syntax not supported yet!")
+    }
+
+    /**
+     * Load OWL data in Functional syntax into an [[RDD]][String].
+     * @return the [[OWLExpressionsRDD]]
+     */
+    def functional: String => OWLExpressionsRDD = path => {
+      ManchesterSyntaxOWLExpressionsRDDBuilder.build(spark, path)
+    }
+
+    /**
+     * Load OWL data in Manchester syntax into an [[RDD]][String].
+     * @return the [[OWLExpressionsRDD]]
+     */
+    def manchester: String => OWLExpressionsRDD = path => {
+      ManchesterSyntaxOWLExpressionsRDDBuilder.build(spark, path)
+    }
+
+  }
+
+}

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/FunctionalSyntaxOWLAxiomsRDDBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/FunctionalSyntaxOWLAxiomsRDDBuilder.scala
@@ -2,19 +2,19 @@ package net.sansa_stack.owl.spark.rdd
 
 import com.typesafe.scalalogging.Logger
 import net.sansa_stack.owl.common.parsing.FunctionalSyntaxParsing
-import org.apache.spark.SparkContext
 import org.semanticweb.owlapi.io.OWLParserException
+import org.apache.spark.sql.SparkSession
 
 
 object FunctionalSyntaxOWLAxiomsRDDBuilder extends FunctionalSyntaxParsing {
   private val logger = Logger(this.getClass)
 
-  def build(sc: SparkContext, filePath: String): OWLAxiomsRDD = {
-    build(sc, FunctionalSyntaxOWLExpressionsRDDBuilder.build(sc, filePath))
+  def build(spark: SparkSession, filePath: String): OWLAxiomsRDD = {
+    build(spark, FunctionalSyntaxOWLExpressionsRDDBuilder.build(spark, filePath))
   }
 
   // FIXME: It has to be ensured that expressionsRDD is in functional syntax
-  def build(sc: SparkContext, expressionsRDD: OWLExpressionsRDD): OWLAxiomsRDD = {
+  def build(spark: SparkSession, expressionsRDD: OWLExpressionsRDD): OWLAxiomsRDD = {
     expressionsRDD.map(expression => {
       try makeAxiom(expression)
       catch {

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/FunctionalSyntaxOWLExpressionsRDDBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/FunctionalSyntaxOWLExpressionsRDDBuilder.scala
@@ -3,14 +3,14 @@ package net.sansa_stack.owl.spark.rdd
 import net.sansa_stack.owl.common.parsing.{FunctionalSyntaxExpressionBuilder, FunctionalSyntaxPrefixParsing}
 import net.sansa_stack.owl.spark.hadoop.FunctionalSyntaxInputFormat
 import org.apache.hadoop.io.{LongWritable, Text}
-import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
 
 
 object FunctionalSyntaxOWLExpressionsRDDBuilder extends Serializable with FunctionalSyntaxPrefixParsing {
-  def build(sc: SparkContext, filePath: String): OWLExpressionsRDD = {
-    val hadoopRDD = sc.hadoopFile(
+  def build(spark: SparkSession, filePath: String): OWLExpressionsRDD = {
+    val hadoopRDD = spark.sparkContext.hadoopFile(
       filePath, classOf[FunctionalSyntaxInputFormat], classOf[LongWritable],
-      classOf[Text], sc.defaultMinPartitions)
+      classOf[Text], spark.sparkContext.defaultMinPartitions)
 
     val rawRDD = hadoopRDD.map(entry => entry._2.toString)
 

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLAxiomsRDDBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLAxiomsRDDBuilder.scala
@@ -2,16 +2,16 @@ package net.sansa_stack.owl.spark.rdd
 
 import com.typesafe.scalalogging.Logger
 import net.sansa_stack.owl.common.parsing.ManchesterSyntaxParsing
-import org.apache.spark.SparkContext
 import org.semanticweb.owlapi.io.OWLParserException
 import org.semanticweb.owlapi.model.{OWLAxiom, OWLRuntimeException}
+import org.apache.spark.sql.SparkSession
 
 
 object ManchesterSyntaxOWLAxiomsRDDBuilder extends ManchesterSyntaxParsing {
   private val logger = Logger(this.getClass)
 
-  def build(sc: SparkContext, filePath: String): OWLAxiomsRDD = {
-    val res = ManchesterSyntaxOWLExpressionsRDDBuilder.buildAndGetPrefixes(sc, filePath)
+  def build(spark: SparkSession, filePath: String): OWLAxiomsRDD = {
+    val res = ManchesterSyntaxOWLExpressionsRDDBuilder.buildAndGetPrefixes(spark, filePath)
 
     val expressionsRDD: OWLExpressionsRDD = res._1
     val prefixes: Map[String, String] = res._2

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLExpressionsRDDBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLExpressionsRDDBuilder.scala
@@ -1,23 +1,22 @@
 package net.sansa_stack.owl.spark.rdd
 
-import net.sansa_stack.owl.common.parsing.{ManchesterSyntaxExpressionBuilder, ManchesterSyntaxPrefixParsing}
+import net.sansa_stack.owl.common.parsing.{ ManchesterSyntaxExpressionBuilder, ManchesterSyntaxPrefixParsing }
 import net.sansa_stack.owl.spark.hadoop.ManchesterSyntaxInputFormat
-import org.apache.hadoop.io.{LongWritable, Text}
-import org.apache.spark.SparkContext
-
+import org.apache.hadoop.io.{ LongWritable, Text }
+import org.apache.spark.sql.SparkSession
 
 object ManchesterSyntaxOWLExpressionsRDDBuilder extends ManchesterSyntaxPrefixParsing {
-  def build(sc: SparkContext, filePath: String): OWLExpressionsRDD = {
-    buildAndGetPrefixes(sc, filePath)._1
+  def build(spark: SparkSession, filePath: String): OWLExpressionsRDD = {
+    buildAndGetPrefixes(spark, filePath)._1
   }
 
-  private[spark] def buildAndGetPrefixes(sc: SparkContext, filePath: String): (OWLExpressionsRDD, Map[String, String]) = {
-    val rawRDD = sc.hadoopFile(
+  private[spark] def buildAndGetPrefixes(spark: SparkSession, filePath: String): (OWLExpressionsRDD, Map[String, String]) = {
+    val rawRDD = spark.sparkContext.hadoopFile(
       filePath,
       classOf[ManchesterSyntaxInputFormat],
       classOf[LongWritable],
       classOf[Text],
-      sc.defaultMinPartitions).map(_._2.toString)
+      spark.sparkContext.defaultMinPartitions).map(_._2.toString)
 
     val tmp: Array[(String, String)] =
       rawRDD.filter(isPrefixDeclaration(_)).map(parsePrefix).collect()

--- a/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/FunctionalSyntaxOWLAxiomsRDDBuilderTest.scala
+++ b/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/FunctionalSyntaxOWLAxiomsRDDBuilderTest.scala
@@ -1,25 +1,31 @@
 package net.sansa_stack.owl.spark.rdd
 
-import com.holdenkarau.spark.testing.SharedSparkContext
 import org.scalatest.FunSuite
 import org.semanticweb.owlapi.model._
-
+import net.sansa_stack.owl.spark.owl._
+import com.holdenkarau.spark.testing.SharedSparkContext
+import org.apache.spark.sql.SparkSession
 
 class FunctionalSyntaxOWLAxiomsRDDBuilderTest extends FunSuite with SharedSparkContext {
+  lazy val spark = SparkSession.builder().appName(sc.appName).master(sc.master)
+    .config(
+      "spark.kryo.registrator",
+      "net.sansa_stack.owl.spark.dataset.UnmodifiableCollectionKryoRegistrator")
+    .getOrCreate()
+
   var _rdd: OWLAxiomsRDD = null
+  val syntax = Syntax.FUNCTIONAL
 
   def rdd = {
     if (_rdd == null) {
-      _rdd = FunctionalSyntaxOWLAxiomsRDDBuilder.build(
-        sc, "src/test/resources/ont_functional.owl")
-//        sc, "hdfs://localhost:9000/ont_functional.owl")
+      val s = spark.owl(syntax)("src/test/resources/ont_functional.owl")
       _rdd.cache()
     }
     _rdd
   }
 
   test("The number of axioms should match") {
-    val expectedNumberOfAxioms = 67  // = 71 - commented out Import(...) - 3 x null
+    val expectedNumberOfAxioms = 67 // = 71 - commented out Import(...) - 3 x null
     assert(rdd.count() == expectedNumberOfAxioms)
   }
 

--- a/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/FunctionalSyntaxOWLExpressionsRDDBuilderTest.scala
+++ b/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/FunctionalSyntaxOWLExpressionsRDDBuilderTest.scala
@@ -1,16 +1,23 @@
 package net.sansa_stack.owl.spark.rdd
 
-import com.holdenkarau.spark.testing.SharedSparkContext
 import org.scalatest.FunSuite
-
+import com.holdenkarau.spark.testing.SharedSparkContext
+import net.sansa_stack.owl.spark.owl._
+import org.apache.spark.sql.SparkSession
 
 class FunctionalSyntaxOWLExpressionsRDDBuilderTest extends FunSuite with SharedSparkContext {
+  lazy val spark = SparkSession.builder().appName(sc.appName).master(sc.master)
+    .config(
+      "spark.kryo.registrator",
+      "net.sansa_stack.owl.spark.dataset.UnmodifiableCollectionKryoRegistrator")
+    .getOrCreate()
+    
   var _rdd: OWLExpressionsRDD = null
+  val syntax = Syntax.FUNCTIONAL
 
   def rdd = {
     if (_rdd == null) {
-      _rdd = FunctionalSyntaxOWLExpressionsRDDBuilder.build(
-        sc, "src/test/resources/ont_functional.owl")
+      _rdd = spark.owlExpressions(syntax)("src/test/resources/ont_functional.owl")
       _rdd.cache()
     }
 
@@ -35,11 +42,11 @@ several lines")""")
   /* Test disabled since OWLAPI will try to resolve imported ontology which
    * will fail or make the number of axioms unpredictable
    */
-//  test("There should be an import statement") {
-//    val res = rdd.filter(line => line.startsWith("Import")).collect()
-//    assert(res.length == 1)
-//    assert(res(0) == "Import(<http://www.example.com/my/2.0>)")
-//  }
+  //  test("There should be an import statement") {
+  //    val res = rdd.filter(line => line.startsWith("Import")).collect()
+  //    assert(res.length == 1)
+  //    assert(res(0) == "Import(<http://www.example.com/my/2.0>)")
+  //  }
 
   test("There should not be any empty lines") {
     val res = rdd.filter(line => line.trim.isEmpty).collect()

--- a/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLExpressionsRDDBuilderTest.scala
+++ b/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLExpressionsRDDBuilderTest.scala
@@ -2,15 +2,23 @@ package net.sansa_stack.owl.spark.rdd
 
 import com.holdenkarau.spark.testing.SharedSparkContext
 import org.scalatest.FunSuite
+import net.sansa_stack.owl.spark.owl._
+import org.apache.spark.sql.SparkSession
 
 
 class ManchesterSyntaxOWLExpressionsRDDBuilderTest extends FunSuite with SharedSparkContext {
+  lazy val spark = SparkSession.builder().appName(sc.appName).master(sc.master)
+    .config(
+      "spark.kryo.registrator",
+      "net.sansa_stack.owl.spark.dataset.UnmodifiableCollectionKryoRegistrator")
+    .getOrCreate()
+    
   var _rdd: OWLExpressionsRDD = null
+  val syntax = Syntax.MANCHESTER
 
   def rdd = {
     if (_rdd == null) {
-      _rdd = ManchesterSyntaxOWLExpressionsRDDBuilder.build(
-        sc, "src/test/resources/ont_manchester.owl")
+      _rdd = spark.owlExpressions(syntax)("src/test/resources/ont_manchester.owl")
 //        sc, "hdfs://localhost:9000/ont_manchester.owl")
       _rdd.cache()
     }


### PR DESCRIPTION
Hi @patrickwestphal , 
this PR proposes a new way of reading owl files. Instead of using build we implicitly define owl method to be called on SparkSession directly (see below for more details)
```scala
import net.sansa_stack.owl.spark.owl._

val syntax = Syntax.FUNCTIONAL
val rdd = spark.owl(syntax)("src/test/resources/ont_functional.owl")
```
This version supports both types (OWLAxiomsRDD, OWLExpressionsRDD) and the plan is to support for Spark Dataset as well.

Feel free to review and make any changes. 
Best regards,