### PR TITLE
Flink version 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <scala.version>2.11.11</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.2.1</spark.version>
-        <flink.version>1.3.2</flink.version>
+        <flink.version>1.5.0</flink.version>
         <hadoop.common.version>2.7.0</hadoop.common.version>
         <hadoop.mapreduce-client.version>2.7.0</hadoop.mapreduce-client.version>
         <owlapi.version>5.1.3</owlapi.version>

--- a/sansa-owl-flink/src/main/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLExpressionsDataSetBuilder.scala
+++ b/sansa-owl-flink/src/main/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLExpressionsDataSetBuilder.scala
@@ -3,19 +3,21 @@ package net.sansa_stack.owl.flink.dataset
 import net.sansa_stack.owl.common.parsing.{FunctionalSyntaxExpressionBuilder, FunctionalSyntaxPrefixParsing}
 import net.sansa_stack.owl.flink.hadoop.FunctionalSyntaxInputFormat
 import org.apache.flink.api.scala.ExecutionEnvironment
+import org.apache.flink.hadoopcompatibility.scala.HadoopInputs
 import org.apache.hadoop.io.{LongWritable, Text}
 
 
 object FunctionalSyntaxOWLExpressionsDataSetBuilder extends FunctionalSyntaxPrefixParsing {
   def build(env: ExecutionEnvironment, filePath: String): OWLExpressionsDataSet = {
     import org.apache.flink.api.scala._
-    val hadoopDataSet: DataSet[(LongWritable, Text)] =
-      env.readHadoopFile[LongWritable, Text](
-        new FunctionalSyntaxInputFormat,
-        classOf[LongWritable],
-        classOf[Text],
-        filePath
-      )
+
+    val wrappedFormat = HadoopInputs.readHadoopFile(new FunctionalSyntaxInputFormat,
+      classOf[LongWritable],
+      classOf[Text],
+      filePath)
+
+    val hadoopDataSet: DataSet[(LongWritable, Text)] = env.createInput(wrappedFormat)
+
     val rawDataSet = hadoopDataSet.map(_._2.toString)
 
     val tmp: Seq[(String, String)] = rawDataSet.filter(isPrefixDeclaration(_)).map(parsePrefix(_)).collect()

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLAxiomsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLAxiomsDataSetBuilderTest.scala
@@ -17,7 +17,7 @@ class FunctionalSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
   def dataSet = {
     if (_dataSet == null) {
       _dataSet = FunctionalSyntaxOWLAxiomsDataSetBuilder.build(
-        env, "src/test/resources/ont_functional.owl")
+        env, this.getClass.getClassLoader.getResource("ont_functional.owl").getPath)
 //        env, "hdfs://localhost:9000/ont_functional.owl")
     }
     _dataSet

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLExpressionsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLExpressionsDataSetBuilderTest.scala
@@ -10,7 +10,7 @@ class FunctionalSyntaxOWLExpressionsDataSetBuilderTest extends FunSuite {
   def dataSet: OWLExpressionsDataSet = {
     if (_dataSet == null) {
       _dataSet = FunctionalSyntaxOWLExpressionsDataSetBuilder.build(
-        env, "src/test/resources/ont_functional.owl")
+        env, this.getClass.getClassLoader.getResource("ont_functional.owl").getPath)
     }
     _dataSet
   }

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLAxiomsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLAxiomsDataSetBuilderTest.scala
@@ -24,7 +24,7 @@ class ManchesterSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
   def dataSet = {
     if (_dataSet == null) {
       _dataSet = ManchesterSyntaxOWLAxiomsDataSetBuilder.build(
-        env, "src/test/resources/ont_manchester.owl")
+        env, this.getClass.getClassLoader.getResource("ont_manchester.owl").getPath)
 //        env, "hdfs://localhost:9000/ont_manchester.owl")
     }
 

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLExpressionsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLExpressionsDataSetBuilderTest.scala
@@ -10,7 +10,7 @@ class ManchesterSyntaxOWLExpressionsDataSetBuilderTest extends FunSuite {
   def dataSet: OWLExpressionsDataSet = {
     if (_dataSet == null) {
       _dataSet = ManchesterSyntaxOWLExpressionsDataSetBuilder.build(
-        env, "src/test/resources/ont_manchester.owl")
+        env, this.getClass.getClassLoader.getResource("ont_manchester.owl").getPath)
 //        env, "hdfs://localhost:9000/ont_manchester.owl")
     }
     _dataSet


### PR DESCRIPTION
Needed some modifications within the custom input formats as Flink
supports Hadoop based input formats via compatibility layer only.