### PR TITLE
Provide implicit wrapper for reading OWL files on Flink.

### DIFF
--- a/sansa-owl-flink/src/main/scala/net/sansa_stack/owl/flink/owl/package.scala
+++ b/sansa-owl-flink/src/main/scala/net/sansa_stack/owl/flink/owl/package.scala
@@ -1,0 +1,91 @@
+package net.sansa_stack.owl.flink
+
+import org.apache.flink.api.scala.{ DataSet, ExecutionEnvironment }
+
+import net.sansa_stack.owl.flink.dataset.{
+  OWLAxiomsDataSet,
+  OWLExpressionsDataSet,
+  FunctionalSyntaxOWLAxiomsDataSetBuilder,
+  ManchesterSyntaxOWLAxiomsDataSetBuilder,
+  FunctionalSyntaxOWLExpressionsDataSetBuilder,
+  ManchesterSyntaxOWLExpressionsDataSetBuilder
+}
+
+/**
+ * Wrap up implicit classes/methods to read OWL data into a [[DataSet]].
+ *
+ * @author Gezim Sejdiu
+ */
+package object owl {
+
+  object Syntax extends Enumeration {
+    val FUNCTIONAL, MANCHESTER, OWLXML = Value
+  }
+
+  /**
+   * Adds methods, `owl(syntax: Syntax)`, `functional` and `manchester`,
+   * to [[ExecutionEnvironment]] that allows to read owl files.
+   */
+  implicit class OWLAxiomReader(env: ExecutionEnvironment) {
+    /**
+     * Load RDF data into a `DataSet[OWLAxiom].
+     * Currently, only functional and manchester syntax are supported
+     * @param syntax of the OWL (functional or manchester)
+     * @return a [[OWLAxiomsDataSet]]
+     */
+    def owl(syntax: Syntax.Value): String => OWLAxiomsDataSet = syntax match {
+      case Syntax.FUNCTIONAL => functional
+      case Syntax.MANCHESTER => manchester
+      case _                 => throw new IllegalArgumentException(s"${syntax} syntax not supported yet!")
+    }
+
+    /**
+     * Load OWL data in Functional syntax into an [[DataSet]][OWLAxiom].
+     * @return the [[OWLAxiomsDataSet]]
+     */
+    def functional: String => OWLAxiomsDataSet = path => {
+      FunctionalSyntaxOWLAxiomsDataSetBuilder.build(env, path)
+    }
+
+    /**
+     * Load OWL data in Manchester syntax into an [[DataSet]][OWLAxiom].
+     * @return the [[OWLAxiomsDataSet]]
+     */
+    def manchester: String => OWLAxiomsDataSet = path => {
+      ManchesterSyntaxOWLAxiomsDataSetBuilder.build(env, path)
+    }
+
+  }
+
+  implicit class OWLExpressionsReader(env: ExecutionEnvironment) {
+    /**
+     * Load RDF data into a `DataSet[String].
+     * Currently, only functional and manchester syntax are supported
+     * @param syntax of the OWL (functional or manchester)
+     * @return a [[OWLExpressionsDataSet]]
+     */
+    def owlExpressions(syntax: Syntax.Value): String => OWLExpressionsDataSet = syntax match {
+      case Syntax.FUNCTIONAL => functional
+      case Syntax.MANCHESTER => manchester
+      case _                 => throw new IllegalArgumentException(s"${syntax} syntax not supported yet!")
+    }
+
+    /**
+     * Load OWL data in Functional syntax into an [[DataSet]][String].
+     * @return the [[OWLExpressionsDataSet]]
+     */
+    def functional: String => OWLExpressionsDataSet = path => {
+      FunctionalSyntaxOWLExpressionsDataSetBuilder.build(env, path)
+    }
+
+    /**
+     * Load OWL data in Manchester syntax into an [[DataSet]][String].
+     * @return the [[OWLExpressionsDataSet]]
+     */
+    def manchester: String => OWLExpressionsDataSet = path => {
+      ManchesterSyntaxOWLExpressionsDataSetBuilder.build(env, path)
+    }
+
+  }
+
+}

--- a/sansa-owl-flink/src/main/scala/net/sansa_stack/owl/flink/owl/package.scala
+++ b/sansa-owl-flink/src/main/scala/net/sansa_stack/owl/flink/owl/package.scala
@@ -3,12 +3,12 @@ package net.sansa_stack.owl.flink
 import org.apache.flink.api.scala.{ DataSet, ExecutionEnvironment }
 
 import net.sansa_stack.owl.flink.dataset.{
-  OWLAxiomsDataSet,
-  OWLExpressionsDataSet,
   FunctionalSyntaxOWLAxiomsDataSetBuilder,
-  ManchesterSyntaxOWLAxiomsDataSetBuilder,
   FunctionalSyntaxOWLExpressionsDataSetBuilder,
-  ManchesterSyntaxOWLExpressionsDataSetBuilder
+  ManchesterSyntaxOWLAxiomsDataSetBuilder,
+  ManchesterSyntaxOWLExpressionsDataSetBuilder,
+  OWLAxiomsDataSet,
+  OWLExpressionsDataSet
 }
 
 /**
@@ -36,7 +36,7 @@ package object owl {
     def owl(syntax: Syntax.Value): String => OWLAxiomsDataSet = syntax match {
       case Syntax.FUNCTIONAL => functional
       case Syntax.MANCHESTER => manchester
-      case _                 => throw new IllegalArgumentException(s"${syntax} syntax not supported yet!")
+      case _ => throw new IllegalArgumentException(s"${syntax} syntax not supported yet!")
     }
 
     /**
@@ -67,7 +67,7 @@ package object owl {
     def owlExpressions(syntax: Syntax.Value): String => OWLExpressionsDataSet = syntax match {
       case Syntax.FUNCTIONAL => functional
       case Syntax.MANCHESTER => manchester
-      case _                 => throw new IllegalArgumentException(s"${syntax} syntax not supported yet!")
+      case _ => throw new IllegalArgumentException(s"${syntax} syntax not supported yet!")
     }
 
     /**

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLAxiomsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLAxiomsDataSetBuilderTest.scala
@@ -3,31 +3,31 @@ package net.sansa_stack.owl.flink.dataset
 import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer
 import org.apache.flink.api.scala.ExecutionEnvironment
 import org.scalatest.FunSuite
-import org.semanticweb.owlapi.model.{OWLAsymmetricObjectPropertyAxiom, OWLDataPropertyAssertionAxiom, OWLDisjointObjectPropertiesAxiom, OWLEquivalentObjectPropertiesAxiom, OWLFunctionalObjectPropertyAxiom, OWLInverseFunctionalObjectPropertyAxiom, OWLInverseObjectPropertiesAxiom, OWLIrreflexiveObjectPropertyAxiom, OWLNegativeDataPropertyAssertionAxiom, OWLNegativeObjectPropertyAssertionAxiom, OWLObjectPropertyAssertionAxiom, OWLObjectPropertyDomainAxiom, OWLObjectPropertyRangeAxiom, OWLReflexiveObjectPropertyAxiom, OWLSubObjectPropertyOfAxiom, OWLSubPropertyChainOfAxiom, OWLSymmetricObjectPropertyAxiom, OWLTransitiveObjectPropertyAxiom, SWRLRule, _}
-
+import org.semanticweb.owlapi.model.{ OWLAsymmetricObjectPropertyAxiom, OWLDataPropertyAssertionAxiom, OWLDisjointObjectPropertiesAxiom, OWLEquivalentObjectPropertiesAxiom, OWLFunctionalObjectPropertyAxiom, OWLInverseFunctionalObjectPropertyAxiom, OWLInverseObjectPropertiesAxiom, OWLIrreflexiveObjectPropertyAxiom, OWLNegativeDataPropertyAssertionAxiom, OWLNegativeObjectPropertyAssertionAxiom, OWLObjectPropertyAssertionAxiom, OWLObjectPropertyDomainAxiom, OWLObjectPropertyRangeAxiom, OWLReflexiveObjectPropertyAxiom, OWLSubObjectPropertyOfAxiom, OWLSubPropertyChainOfAxiom, OWLSymmetricObjectPropertyAxiom, OWLTransitiveObjectPropertyAxiom, SWRLRule, _ }
 
 class FunctionalSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
+  import net.sansa_stack.owl.flink.owl._
+
   val env = ExecutionEnvironment.getExecutionEnvironment
 
   // scalastyle:off classforname
   env.getConfig.addDefaultKryoSerializer(
     Class.forName("java.util.Collections$UnmodifiableCollection"),
-    classOf[UnmodifiableCollectionsSerializer]
-  )
+    classOf[UnmodifiableCollectionsSerializer])
   // scalastyle:on classforname
 
   var _dataSet: OWLAxiomsDataSet = null
+  val syntax = Syntax.FUNCTIONAL
   def dataSet: OWLAxiomsDataSet = {
     if (_dataSet == null) {
-      _dataSet = FunctionalSyntaxOWLAxiomsDataSetBuilder.build(
-        env, this.getClass.getClassLoader.getResource("ont_functional.owl").getPath)
-//        env, "hdfs://localhost:9000/ont_functional.owl")
+      _dataSet = env.owl(syntax)(this.getClass.getClassLoader.getResource("ont_functional.owl").getPath)
+      //        env, "hdfs://localhost:9000/ont_functional.owl")
     }
     _dataSet
   }
 
   test("The number of axioms should match") {
-    val expectedNumberOfAxioms = 67  // = 71 - commented out Import(...) - 3 x null
+    val expectedNumberOfAxioms = 67 // = 71 - commented out Import(...) - 3 x null
     assert(dataSet.count() == expectedNumberOfAxioms)
   }
 

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLExpressionsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLExpressionsDataSetBuilderTest.scala
@@ -3,14 +3,15 @@ package net.sansa_stack.owl.flink.dataset
 import org.apache.flink.api.scala.ExecutionEnvironment
 import org.scalatest.FunSuite
 
-
 class FunctionalSyntaxOWLExpressionsDataSetBuilderTest extends FunSuite {
+  import net.sansa_stack.owl.flink.owl._
   lazy val env = ExecutionEnvironment.getExecutionEnvironment
   var _dataSet: OWLExpressionsDataSet = null
+  val syntax = Syntax.FUNCTIONAL
+
   def dataSet: OWLExpressionsDataSet = {
     if (_dataSet == null) {
-      _dataSet = FunctionalSyntaxOWLExpressionsDataSetBuilder.build(
-        env, this.getClass.getClassLoader.getResource("ont_functional.owl").getPath)
+      _dataSet = env.owlExpressions(syntax)(this.getClass.getClassLoader.getResource("ont_functional.owl").getPath)
     }
     _dataSet
   }

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLAxiomsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLAxiomsDataSetBuilderTest.scala
@@ -8,27 +8,28 @@ import de.javakaffee.kryoserializers.UnmodifiableCollectionsSerializer
 import org.apache.flink.api.scala.ExecutionEnvironment
 import org.scalatest.FunSuite
 import org.semanticweb.owlapi.apibinding.OWLManager
-import org.semanticweb.owlapi.model.{OWLDataPropertyAssertionAxiom, _}
+import org.semanticweb.owlapi.model.{ OWLDataPropertyAssertionAxiom, _ }
 import org.semanticweb.owlapi.vocab.XSDVocabulary
-import uk.ac.manchester.cs.owl.owlapi.{OWLDatatypeImpl, OWLEquivalentClassesAxiomImpl}
+import uk.ac.manchester.cs.owl.owlapi.{ OWLDatatypeImpl, OWLEquivalentClassesAxiomImpl }
 
 class ManchesterSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
+  import net.sansa_stack.owl.flink.owl._
   lazy val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
 
   // scalastyle:off classforname
   env.getConfig.addDefaultKryoSerializer(
     Class.forName("java.util.Collections$UnmodifiableCollection"),
-    classOf[UnmodifiableCollectionsSerializer]
-  )
+    classOf[UnmodifiableCollectionsSerializer])
   // scalastyle:on classforname
 
   val dataFactory = OWLManager.getOWLDataFactory
   var _dataSet: OWLAxiomsDataSet = null
+  val syntax = Syntax.MANCHESTER
+
   def dataSet: OWLAxiomsDataSet = {
     if (_dataSet == null) {
-      _dataSet = ManchesterSyntaxOWLAxiomsDataSetBuilder.build(
-        env, this.getClass.getClassLoader.getResource("ont_manchester.owl").getPath)
-//        env, "hdfs://localhost:9000/ont_manchester.owl")
+      _dataSet = env.owl(syntax)(this.getClass.getClassLoader.getResource("ont_manchester.owl").getPath)
+      //        env, "hdfs://localhost:9000/ont_manchester.owl")
     }
 
     _dataSet
@@ -555,8 +556,7 @@ class ManchesterSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
     val expectedClasses = Set(
       dataFactory.getOWLClass("http://ex.com/bar#Cl1OrNegate"),
       dataFactory.getOWLClass("http://ex.com/bar#Cls1"),
-      dataFactory.getOWLClass("http://ex.com/bar#ComplementCls1")
-    )
+      dataFactory.getOWLClass("http://ex.com/bar#ComplementCls1"))
 
     import org.apache.flink.api.scala._
     val filteredDataSet: DataSet[OWLDisjointUnionAxiom] =
@@ -580,8 +580,7 @@ class ManchesterSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
     val expectedNumberOfAxioms = 2
     val expectedClasses = Set(
       dataFactory.getOWLClass("http://ex.com/bar#DataMin3Prop1"),
-      dataFactory.getOWLClass("http://ex.com/bar#DataMax2Prop1")
-    )
+      dataFactory.getOWLClass("http://ex.com/bar#DataMax2Prop1"))
 
     import org.apache.flink.api.scala._
     val filteredDataSet: DataSet[OWLDisjointClassesAxiom] =
@@ -592,14 +591,13 @@ class ManchesterSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
     assert(
       filteredDataSet.filter(
         _.classExpressions().collect(Collectors.toSet()) == expectedClasses.asJava).count() ==
-      expectedNumberOfAxioms)
+        expectedNumberOfAxioms)
   }
 
   def equivClasses(ce1: OWLClassExpression, ce2: OWLClassExpression): OWLEquivalentClassesAxiom =
     new OWLEquivalentClassesAxiomImpl(
       List(ce1, ce2).asJavaCollection,
-      List.empty[OWLAnnotation].asJavaCollection
-    )
+      List.empty[OWLAnnotation].asJavaCollection)
 
   test("Equivalent classes axioms should be created correctly") {
     // 57) EquivalentClasses(<http://ex.com/bar#AllIndividualsCls> ObjectOneOf(<http://ex.com/foo#indivA> <http://ex.com/foo#indivB>))
@@ -730,8 +728,7 @@ class ManchesterSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
         df.getOWLClass("http://ex.com/bar#UnionCls"),
         df.getOWLObjectUnionOf(
           df.getOWLClass("http://ex.com/bar#Cls1"),
-          df.getOWLClass("http://ex.com/bar#Cls2")))
-    )
+          df.getOWLClass("http://ex.com/bar#Cls2"))))
 
     import org.apache.flink.api.scala._
     val filteredDataSet: DataSet[OWLEquivalentClassesAxiom] =
@@ -773,8 +770,7 @@ class ManchesterSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
     val expectedNumberOfAxioms = 2
     val expectedRanges = Set(
       (dataFactory.getOWLDataProperty("http://ex.com/bar#dataProp1"), XSDVocabulary.STRING.getIRI),
-      (dataFactory.getOWLDataProperty("http://ex.com/bar#dataProp2"), XSDVocabulary.INT.getIRI)
-    )
+      (dataFactory.getOWLDataProperty("http://ex.com/bar#dataProp2"), XSDVocabulary.INT.getIRI))
 
     import org.apache.flink.api.scala._
     val filteredDataSet: DataSet[OWLDataPropertyRangeAxiom] =

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLExpressionsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLExpressionsDataSetBuilderTest.scala
@@ -3,15 +3,16 @@ package net.sansa_stack.owl.flink.dataset
 import org.apache.flink.api.scala.ExecutionEnvironment
 import org.scalatest.FunSuite
 
-
 class ManchesterSyntaxOWLExpressionsDataSetBuilderTest extends FunSuite {
+  import net.sansa_stack.owl.flink.owl._
   lazy val env = ExecutionEnvironment.getExecutionEnvironment
   var _dataSet: OWLExpressionsDataSet = null
+  val syntax = Syntax.MANCHESTER
+
   def dataSet: OWLExpressionsDataSet = {
     if (_dataSet == null) {
-      _dataSet = ManchesterSyntaxOWLExpressionsDataSetBuilder.build(
-        env, this.getClass.getClassLoader.getResource("ont_manchester.owl").getPath)
-//        env, "hdfs://localhost:9000/ont_manchester.owl")
+      _dataSet = env.owlExpressions(syntax)(this.getClass.getClassLoader.getResource("ont_manchester.owl").getPath)
+      //        env, "hdfs://localhost:9000/ont_manchester.owl")
     }
     _dataSet
   }


### PR DESCRIPTION
Hi @patrickwestphal ,
this PR proposes a new way of reading owl files on Flink. Instead of using build we implicitly define owl method to be called on `env` directly (see below for more details)
```scala
import net.sansa_stack.owl.flink.owl._

val syntax = Syntax.FUNCTIONAL
val rdd = env.owl(syntax)("src/test/resources/ont_functional.owl")
```
This version supports both types (`OWLAxiomsDataSet`, `OWLExpressionsDataSet`).

Feel free to review and make any changes.
Best regards,