### PR TITLE
Add OWL implicits example using RDDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SANSA OWL
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.sansa-stack/sansa-owl-parent_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.sansa-stack/sansa-owl-parent_2.11)
 [![Build Status](https://ci.aksw.org/jenkins/job/SANSA%20OWL%20Layer/job/develop/badge/icon)](https://ci.aksw.org/jenkins/job/SANSA%20OWL%20Layer/job/develop/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Twitter](https://img.shields.io/twitter/follow/SANSA_Stack.svg?style=social)](https://twitter.com/SANSA_Stack)
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -47,9 +47,14 @@ or parsed [OWL API](http://owlapi.sourceforge.net/) axiom objects. We call these
 
 ## Usage
 
-The following Scala code shows how to read an OWL file in Functional Syntax (be it a local file or a file residing in HDFS) into a Spark dataset:
+The following Scala code shows how to read an OWL file in Functional Syntax (be it a local file or a file residing in HDFS) into a Spark RDD:
 ```scala
-val dataset = FunctionalSyntaxOWLAxiomsDatasetBuilder.build(sparkSession, "path/to/functional/syntax/file.owl")
+import net.sansa_stack.owl.spark.owl._
+
+val syntax = Syntax.FUNCTIONAL
+val input = "path/to/functional/syntax/file.owl"
+
+val rdd = spark.owl(syntax)(input)
 ```
 We also provide builder objects for the other described OWL formats and data structures. The same holds for the Flink implementations. An overview is given in the [FAQ section of the SANSA project page](http://sansa-stack.net/faq/#owl-processing). Further documentation about the builder objects can also be found on the [ScalaDoc page](http://sansa-stack.net/scaladocs/).
 

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLAxiomsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/FunctionalSyntaxOWLAxiomsDataSetBuilderTest.scala
@@ -21,7 +21,6 @@ class FunctionalSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
   def dataSet: OWLAxiomsDataSet = {
     if (_dataSet == null) {
       _dataSet = env.owl(syntax)(this.getClass.getClassLoader.getResource("ont_functional.owl").getPath)
-      //        env, "hdfs://localhost:9000/ont_functional.owl")
     }
     _dataSet
   }

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLAxiomsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLAxiomsDataSetBuilderTest.scala
@@ -29,7 +29,6 @@ class ManchesterSyntaxOWLAxiomsDataSetBuilderTest extends FunSuite {
   def dataSet: OWLAxiomsDataSet = {
     if (_dataSet == null) {
       _dataSet = env.owl(syntax)(this.getClass.getClassLoader.getResource("ont_manchester.owl").getPath)
-      //        env, "hdfs://localhost:9000/ont_manchester.owl")
     }
 
     _dataSet

--- a/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLExpressionsDataSetBuilderTest.scala
+++ b/sansa-owl-flink/src/test/scala/net/sansa_stack/owl/flink/dataset/ManchesterSyntaxOWLExpressionsDataSetBuilderTest.scala
@@ -12,7 +12,6 @@ class ManchesterSyntaxOWLExpressionsDataSetBuilderTest extends FunSuite {
   def dataSet: OWLExpressionsDataSet = {
     if (_dataSet == null) {
       _dataSet = env.owlExpressions(syntax)(this.getClass.getClassLoader.getResource("ont_manchester.owl").getPath)
-      //        env, "hdfs://localhost:9000/ont_manchester.owl")
     }
     _dataSet
   }

--- a/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLAxiomsRDDBuilderTest.scala
+++ b/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLAxiomsRDDBuilderTest.scala
@@ -29,7 +29,6 @@ class ManchesterSyntaxOWLAxiomsRDDBuilderTest extends FunSuite with SharedSparkC
   def rdd: OWLAxiomsRDD = {
     if (_rdd == null) {
       _rdd = spark.owl(syntax)(filePath)
-      //        sc, "hdfs://localhost:9000/ont_manchester.owl")
       _rdd.cache()
     }
 

--- a/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLExpressionsRDDBuilderTest.scala
+++ b/sansa-owl-spark/src/test/scala/net/sansa_stack/owl/spark/rdd/ManchesterSyntaxOWLExpressionsRDDBuilderTest.scala
@@ -21,7 +21,6 @@ class ManchesterSyntaxOWLExpressionsRDDBuilderTest extends FunSuite with SharedS
   def rdd: OWLExpressionsRDD = {
     if (_rdd == null) {
       _rdd = spark.owlExpressions(syntax)(filePath)
-//        sc, "hdfs://localhost:9000/ont_manchester.owl")
       _rdd.cache()
     }
 


### PR DESCRIPTION
Hi Patrick, 
this small PR updates the [usage example](https://github.com/SANSA-Stack/SANSA-OWL#usage) by providing a better example using OWL implicit calls and RDD aligned with our latest API changes.

Best regards,