### PR TITLE
Rdfxml parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,10 @@
         <spark.version>2.4.0</spark.version>
         <flink.version>1.7.0</flink.version>
         <hadoop.common.version>2.8.1</hadoop.common.version>
+        <hadoop.version>2.8.3</hadoop.version>
         <hadoop.mapreduce-client.version>2.8.1</hadoop.mapreduce-client.version>
         <owlapi.version>5.1.5</owlapi.version>
+        <jena.version>3.11.0</jena.version>
         <scalastyle.config.path>${project.basedir}/scalastyle-config.xml</scalastyle.config.path>
     </properties>
 
@@ -99,6 +101,29 @@
                 <groupId>de.javakaffee</groupId>
                 <artifactId>kryo-serializers</artifactId>
                 <version>0.42</version>
+            </dependency>
+
+            <!-- Apache JENA 3.x-->
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena</artifactId>
+                <version>${jena.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-core</artifactId>
+                <version>${jena.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-arq</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-tdb</artifactId>
+                <version>${jena.version}</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- Apache Flink dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,12 @@
         <hadoop.mapreduce-client.version>2.8.1</hadoop.mapreduce-client.version>
         <owlapi.version>5.1.5</owlapi.version>
         <jena.version>3.11.0</jena.version>
-        <scalastyle.config.path>${project.basedir}/scalastyle-config.xml</scalastyle.config.path>
+        <!-- since the scalastyle plugin is only executed in the child modules -->
+        <scalastyle.config.path>${project.basedir}/../scalastyle-config.xml</scalastyle.config.path>
+        <!-- Default case for the child modules. Will be overridden and set to
+             true by the root-dir profile which detects when we're in the parent
+             module -->
+        <scalastyle.skip>false</scalastyle.skip>
     </properties>
 
 
@@ -106,24 +111,8 @@
             <!-- Apache JENA 3.x-->
             <dependency>
                 <groupId>org.apache.jena</groupId>
-                <artifactId>jena</artifactId>
-                <version>${jena.version}</version>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
                 <artifactId>jena-core</artifactId>
                 <version>${jena.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-arq</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-tdb</artifactId>
-                <version>${jena.version}</version>
-                <scope>provided</scope>
             </dependency>
 
             <!-- Apache Flink dependencies -->
@@ -212,7 +201,6 @@
                 <artifactId>guice-multibindings</artifactId>
                 <version>4.0</version>
             </dependency>
-
 
             <!-- MLlib dependencies -->
             <dependency>
@@ -332,6 +320,7 @@
                     <artifactId>scalastyle-maven-plugin</artifactId>
                     <version>1.0.0</version>
                     <configuration>
+                        <skip>${scalastyle.skip}</skip>
                         <verbose>false</verbose>
                         <failOnViolation>true</failOnViolation>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -359,15 +348,19 @@
 
     <profiles>
         <!-- profile necessary for Scalastyle plugin to find the conf file -->
+        <!-- if the file ./scalastyle-config.xml exists, we're in the parent
+             module (or 'root directory'). In this case it doesn't make sense to
+             run the scalastyle plugin. Thus the ${scalastyle.skip} property is
+             set to true and the plugin won't be executed -->
         <profile>
             <id>root-dir</id>
             <activation>
                 <file>
-                    <exists>${project.basedir}/../../scalastyle-config.xml</exists>
+                    <exists>scalastyle-config.xml</exists>
                 </file>
             </activation>
             <properties>
-                <scalastyle.config.path>${project.basedir}/../scalastyle-config.xml</scalastyle.config.path>
+                <scalastyle.skip>true</scalastyle.skip>
             </properties>
         </profile>
 

--- a/sansa-owl-common/pom.xml
+++ b/sansa-owl-common/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
+            <version>${jena.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>

--- a/sansa-owl-common/pom.xml
+++ b/sansa-owl-common/pom.xml
@@ -15,12 +15,6 @@
 
     <dependencies>
 
-        <!-- SANSA OWL Spark dependencies -->
-        <dependency>
-            <groupId>net.sansa-stack</groupId>
-            <artifactId>sansa-owl-spark_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <!-- Scala dependencies -->
         <dependency>

--- a/sansa-owl-common/pom.xml
+++ b/sansa-owl-common/pom.xml
@@ -14,6 +14,14 @@
     <version>0.4.2-SNAPSHOT</version>
 
     <dependencies>
+
+        <!-- SANSA OWL Spark dependencies -->
+        <dependency>
+            <groupId>net.sansa-stack</groupId>
+            <artifactId>sansa-owl-spark_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- Scala dependencies -->
         <dependency>
             <groupId>org.scala-lang</groupId>
@@ -24,6 +32,14 @@
             <artifactId>scala-java8-compat_2.12</artifactId>
             <version>0.9.0</version>
         </dependency>
+
+        <!-- slf4j Logger dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+
 
         <!-- OWL API dependencies -->
         <dependency>
@@ -59,7 +75,19 @@
             <scope>provided</scope>
         </dependency>
 
-
+        <!-- Spark dependencies -->
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.11</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>de.javakaffee</groupId>
+            <artifactId>kryo-serializers</artifactId>
+        </dependency>
         <!-- parsing dependencies -->
         <dependency>
             <groupId>org.scala-lang.modules</groupId>

--- a/sansa-owl-common/pom.xml
+++ b/sansa-owl-common/pom.xml
@@ -19,6 +19,11 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-java8-compat_2.12</artifactId>
+            <version>0.9.0</version>
+        </dependency>
 
         <!-- OWL API dependencies -->
         <dependency>
@@ -30,10 +35,41 @@
             <artifactId>owlapi-apibinding</artifactId>
         </dependency>
 
+        <!-- Apache JENA 3.x-->
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena</artifactId>
+            <version>${jena.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-core</artifactId>
+            <version>${jena.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-arq</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-tdb</artifactId>
+            <version>${jena.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
         <!-- parsing dependencies -->
         <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
+        </dependency>
+
+        <!-- scala-java8 -->
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-java8-compat_2.12</artifactId>
+            <version>0.9.0</version>
         </dependency>
 
         <!-- Testing dependencies -->

--- a/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
+++ b/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
@@ -258,8 +258,8 @@ trait RDFXMLSyntaxPrefixParsing {
     * pair (prefix, namespace URI)
     *
     * @param line Sth like
-    * xmlns:="http://swat.cse.lehigh.edu/onto/univ-bench.owl#"
-	  * xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    *             xmlns:="http://swat.cse.lehigh.edu/onto/univ-bench.owl#"
+    *             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     */
 
   def parsePrefix(line: String): (String, String) = {

--- a/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
+++ b/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
@@ -1,0 +1,218 @@
+package net.sansa_stack.owl.common.parsing
+
+import java.io._
+import java.util.ArrayList
+
+import collection.JavaConverters._
+import org.apache.jena.rdf.model.{Model, ModelFactory, Statement}
+import org.semanticweb.owlapi.apibinding.OWLManager
+import org.semanticweb.owlapi.model.OWLAxiom
+import org.semanticweb.owlapi.model.OWLOntology
+
+import scala.collection.immutable.Stream
+import scala.compat.java8.StreamConverters._
+import scala.util.matching.Regex
+
+/**
+  * Object containing several constants used by the RDFXMLSyntaxParsing
+  * trait and the RDFXMLSyntaxExpressionBuilder
+  */
+
+object RDFXMLSyntaxParsing {
+  /** marker used to store the prefix for the default namespace */
+  val _empty = "_EMPTY_"
+
+  val prefixPattern: Regex = "xmlns\\s*:\\s*[a-zA-Z][a-zA-Z0-9_]*\\s*=\\s*([\"'])(?:(?=(\\\\?))\\2.)*?\\1".r
+  val ontologyPattern: Regex = "Ontology\\(<(.*)>".r
+}
+
+/**
+  * Trait to support the parsing of input OWL files in RDFXML syntax.
+  * This trait mainly defines how to make axioms from input RDFXML syntax expressions.
+  */
+
+trait RDFXMLSyntaxParsing {
+
+  // private val logger = Logger(classOf[FunctionalSyntaxParsing])
+
+//  private def parser = new OWLXMLParserFactory().createParser()
+
+  private def man = OWLManager.createOWLOntologyManager()
+
+  // private def ontConf = man.getOntologyLoaderConfiguration
+
+  def RecordParse(record: String, prefixes: String): ArrayList[OWLAxiom] = {
+
+    var OWLAxioms = new ArrayList[OWLAxiom]()
+
+    val model = ModelFactory.createDefaultModel()
+
+    val modelText = "<?xml version=\"1.0\" encoding=\"utf-8\" ?> \n" + prefixes + record + "</rdf:RDF>"
+
+    model.read(new ByteArrayInputStream(modelText.getBytes()), "http://swat.cse.lehigh.edu")
+
+    val iter = model.listStatements()
+
+    while (iter.hasNext()) {
+      val stmt = iter.next()
+      val axiomSet = makeAxiom(stmt).toList.asJavaCollection
+      OWLAxioms.addAll(axiomSet)
+    }
+
+    OWLAxioms
+
+  }
+
+  /**
+    * Builds a snippet conforming to the RDFXML syntax which then can
+    * be parsed by the OWLAPI RDFXML syntax parser.
+    * A single expression, e.g.
+    *
+    * <rdf:RDF
+    * xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    * xmlns:owl="http://www.w3.org/2002/07/owl#">
+    * <owl:Class rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+    * </rdf:RDF>
+    *
+    * then we will get
+    * Declaration(Class("http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"))
+    *
+    *
+    * @param st A Statement containing an expression in RDFXML syntax
+    * @return The set of axioms corresponding to the expression.
+    */
+
+  def makeAxiom(st: Statement): Set[OWLAxiom] = {
+
+    val model = ModelFactory.createDefaultModel
+    model.add(st)
+
+    val ontology: OWLOntology = getOWLOntology(model)
+
+    val axiomSet: Set[OWLAxiom] = ontology.axioms().toScala[Stream].toSet
+
+    axiomSet
+  }
+
+
+  /**
+    * To get the corresponding OWLOntology of a certain model
+    *
+    * @param model Model
+    * @return OWLOntology corresponding to that model
+    */
+
+  def getOWLOntology(model: Model): OWLOntology = {
+    val in = new PipedInputStream
+    val o = new PipedOutputStream(in)
+
+    new Thread(new Runnable() {
+      def run() : Unit = {
+        model.write(o, "RDF/XML-ABBREV")
+   //     model.write(System.out, "RDF/XML")
+
+        try {
+          o.close()
+        } catch {
+          case e: IOException => e.printStackTrace()
+        }
+
+      }
+    }).start()
+    val ontology : OWLOntology = man.loadOntologyFromOntologyDocument(in)
+    ontology
+
+  }
+}
+
+/**
+  * Trait to support the parsing of prefixes from expressions given in
+  * functional syntax.
+  */
+trait RDFXMLSyntaxPrefixParsing {
+  /**
+    * Parses the prefix declaration of a namespace URI and returns the
+    * pair (prefix, namespace URI)
+    *
+    * @param line Sth like
+    *             xmlns:="http://swat.cse.lehigh.edu/onto/univ-bench.owl#"
+	  *             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    */
+
+  def parsePrefix(line: String): (String, String) = {
+
+    var prefix, uri: String = null
+    var temp: String = line
+
+    line.trim match {
+      case RDFXMLSyntaxParsing.prefixPattern(p, u) =>
+        prefix = p
+        uri = u
+
+    }
+    if (prefix.isEmpty) prefix = RDFXMLSyntaxParsing._empty
+
+    (prefix, uri)
+  }
+
+  def isPrefix(expression: String): Boolean = {
+    RDFXMLSyntaxParsing.prefixPattern.pattern.matcher(expression).matches()
+  }
+}
+
+
+
+ class RDFXMLSyntaxExpressionBuilder (val prefixes: Map[String, String]) extends Serializable {
+
+   def clean(expression: String): String = {
+
+     var trimmedExpr = expression.trim
+
+     /* Throw away expressions that are of no use for further processing:
+      * 1) empty lines
+      * 2) first line of the xml file
+      * 3) the closing, </rdf:RDF> tag
+      * 4) prefix declaration
+      */
+     val discardExpression: Boolean =
+       trimmedExpr.isEmpty  || // 1)
+         trimmedExpr.startsWith("<?xml") ||  // 2)
+         trimmedExpr.startsWith("</rdf:RDF") ||  // 3)
+         trimmedExpr.startsWith("<rdf:RDF") // 4)
+
+     if (discardExpression) {
+       null
+
+     } else {
+       // Expand prefix abbreviations: foo:Bar --> http://foo.com/somePath#Bar
+       for (prefix <- prefixes.keys) {
+         val p = prefix + ":"
+
+         if (trimmedExpr.contains(p)) {
+           val v: String = "<" + prefixes.get(prefix).get
+
+           val pattern = (p + "([a-zA-Z][0-9a-zA-Z_-]*)\\b").r
+
+           // Append ">" to all matched local parts: "foo:car" --> "foo:car>"
+           trimmedExpr = pattern.replaceAllIn(trimmedExpr, m => s"${m.matched}>")
+           // Expand prefix: "foo:car>" --> "http://foo.org/res#car>"
+           trimmedExpr = trimmedExpr.replace(p.toCharArray, v.toCharArray)
+         }
+       }
+
+       // handle default prefix e.g. :Bar --> http://foo.com/defaultPath#Bar
+
+       val pattern = ":[^/][a-zA-Z][0-9a-zA-Z_-]*".r
+       val v: String = "<" + prefixes.get(FunctionalSyntaxParsing._empty).get
+
+       if (prefixes.contains(RDFXMLSyntaxParsing._empty)) {
+         pattern.findAllIn(trimmedExpr).foreach(hit => {
+           val full = hit.replace(":".toCharArray, v.toCharArray)
+           trimmedExpr = trimmedExpr.replace(hit, full + ">")
+         })
+       }
+
+       trimmedExpr
+     }
+   }
+ }

--- a/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
+++ b/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
@@ -33,13 +33,7 @@ object RDFXMLSyntaxParsing {
 
 trait RDFXMLSyntaxParsing {
 
-  // private val logger = Logger(classOf[FunctionalSyntaxParsing])
-
-//  private def parser = new OWLXMLParserFactory().createParser()
-
   private def man = OWLManager.createOWLOntologyManager()
-
-  // private def ontConf = man.getOntologyLoaderConfiguration
 
   def RecordParse(record: String, prefixes: String): ArrayList[OWLAxiom] = {
 
@@ -109,7 +103,6 @@ trait RDFXMLSyntaxParsing {
     new Thread(new Runnable() {
       def run() : Unit = {
         model.write(o, "RDF/XML-ABBREV")
-   //     model.write(System.out, "RDF/XML")
 
         try {
           o.close()
@@ -127,7 +120,7 @@ trait RDFXMLSyntaxParsing {
 
 /**
   * Trait to support the parsing of prefixes from expressions given in
-  * functional syntax.
+  * RDFXML syntax.
   */
 trait RDFXMLSyntaxPrefixParsing {
   /**

--- a/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
+++ b/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
@@ -258,8 +258,8 @@ trait RDFXMLSyntaxPrefixParsing {
     * pair (prefix, namespace URI)
     *
     * @param line Sth like
-    *             xmlns:="http://swat.cse.lehigh.edu/onto/univ-bench.owl#"
-	  *             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    * xmlns:="http://swat.cse.lehigh.edu/onto/univ-bench.owl#"
+	  * xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     */
 
   def parsePrefix(line: String): (String, String) = {
@@ -283,15 +283,14 @@ trait RDFXMLSyntaxPrefixParsing {
   }
 }
 
-
-
  class RDFXMLSyntaxExpressionBuilder (val prefixes: Map[String, String]) extends Serializable {
 
    def clean(expression: String): String = {
 
      var trimmedExpr = expression.trim
 
-     /* Throw away expressions that are of no use for further processing:
+    /**
+      * Throw away expressions that are of no use for further processing:
       * 1) empty lines
       * 2) first line of the xml file
       * 3) the closing, </rdf:RDF> tag

--- a/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
+++ b/sansa-owl-common/src/main/scala/net/sansa_stack/owl/common/parsing/RDFXMLSyntaxParsing.scala
@@ -132,10 +132,11 @@ trait RDFXMLSyntaxParsing {
 
     axiomsRDD.cache()
 
-    /* Case 1: Handler for wrong domain axioms
-     * OWLDataPropertyDomain and OWLObjectPropertyDomain
-     * converted wrong to OWLAnnotationPropertyDomain
-     */
+  /**
+    *  Case 1: Handler for wrong domain axioms
+    *  OWLDataPropertyDomain and OWLObjectPropertyDomain
+    *  converted wrong to OWLAnnotationPropertyDomain
+   */
 
     val declaration = extractAxiom(axiomsRDD, AxiomType.DECLARATION)
       .asInstanceOf[RDD[OWLDeclarationAxiom]]
@@ -188,13 +189,13 @@ trait RDFXMLSyntaxParsing {
         }
       }
 
-    /* Case 2: Handler for wrong subPropertyOf axioms
-      * OWLSubPropertyOf converted wrong to OWLSubAnnotationPropertyOf
-      * instead of OWLSubDataPropertyOf or OWLSubObjectPropertyOf
-      */
+  /**
+    * Case 2: Handler for wrong subPropertyOf axioms
+    * OWLSubPropertyOf converted wrong to OWLSubAnnotationPropertyOf
+    * instead of OWLSubDataPropertyOf or OWLSubObjectPropertyOf
+    */
 
     val subAnnotationProperty = extractAxiom(axiomsRDD, AxiomType.SUB_ANNOTATION_PROPERTY_OF)
-
 
     val subPropertyTransform = subAnnotationProperty.asInstanceOf[RDD[OWLSubAnnotationPropertyOfAxiom]]
       .map { a =>

--- a/sansa-owl-flink/pom.xml
+++ b/sansa-owl-flink/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>scala-library</artifactId>
         </dependency>
 
+        <!-- Logging dependencies -->
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_2.11</artifactId>
+        </dependency>
+
         <!-- Apache Flink dependencies -->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/sansa-owl-spark/pom.xml
+++ b/sansa-owl-spark/pom.xml
@@ -15,6 +15,9 @@
     <name>SANSA OWL layer - SPARK</name>
     <description>A library to read OWL files into Spark.</description>
 
+    <properties>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>net.sansa-stack</groupId>
@@ -22,10 +25,62 @@
             <version>${project.version}</version>
         </dependency>
 
+
+
+        <!-- To remove warnings from xerec parser -->
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.2</version>
+            <scope>${my-scope}</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.parsers</groupId>
+            <artifactId>jaxp-ri</artifactId>
+            <version>1.4.5</version>
+        </dependency>
+
+        <!-- Apache JENA 3.x-->
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena</artifactId>
+            <version>${jena.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-core</artifactId>
+            <version>${jena.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-arq</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-tdb</artifactId>
+            <version>${jena.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
         <!-- Scala dependencies -->
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
+        </dependency>
+
+        <!-- Scala java8 -->
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-java8-compat_2.12</artifactId>
+            <version>0.9.0</version>
         </dependency>
 
         <!-- Spark dependencies -->
@@ -47,9 +102,22 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.common.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-streaming</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_${scala.binary.version}</artifactId>
         </dependency>
 
         <!-- OWL API dependencies -->

--- a/sansa-owl-spark/pom.xml
+++ b/sansa-owl-spark/pom.xml
@@ -25,8 +25,6 @@
             <version>${project.version}</version>
         </dependency>
 
-
-
         <!-- To remove warnings from xerec parser -->
         <dependency>
             <groupId>xalan</groupId>
@@ -49,27 +47,9 @@
         <!-- Apache JENA 3.x-->
         <dependency>
             <groupId>org.apache.jena</groupId>
-            <artifactId>jena</artifactId>
-            <version>${jena.version}</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
             <version>${jena.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-arq</artifactId>
-            <version>${jena.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-tdb</artifactId>
-            <version>${jena.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
 
         <!-- Scala dependencies -->
         <dependency>

--- a/sansa-owl-spark/pom.xml
+++ b/sansa-owl-spark/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
+            <version>${jena.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
@@ -81,6 +82,19 @@
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-java8-compat_2.12</artifactId>
             <version>0.9.0</version>
+        </dependency>
+
+        <!-- Jackson depencency-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.8</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_2.11</artifactId>
+            <version>2.9.8</version>
         </dependency>
 
         <!-- Spark dependencies -->

--- a/sansa-owl-spark/src/main/resources/log4j.properties
+++ b/sansa-owl-spark/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to a log file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=C:\\logging.log
+log4j.appender.file.MaxFileSize=10MB
+log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %C{1}:%L - %m%n
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%r %-5p %C:%L - %m%n
+
+log4j.logger.akka.event.slf4j.Slf4jLogger=ERROR
+log4j.logger.akka.remote.Remoting=ERROR
+log4j.logger.org.spark_project.jetty=ERROR
+log4j.logger.org.apache.spark=ERROR
+log4j.logger.org.apache.hadoop=ERROR
+log4j.logger.org.semanticweb.owlapi=ERROR

--- a/sansa-owl-spark/src/main/resources/univ-bench.rdf
+++ b/sansa-owl-spark/src/main/resources/univ-bench.rdf
@@ -1,0 +1,666 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns="http://swat.cse.lehigh.edu/onto/univ-bench.owl#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:owl="http://www.w3.org/2002/07/owl#"
+	xml:base="http://swat.cse.lehigh.edu/onto/univ-bench.owl">
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+	<rdfs:comment>An university ontology for benchmark tests</rdfs:comment>
+	<rdfs:label>Univ-bench Ontology</rdfs:label>
+	<owl:versionInfo>univ-bench-ontology-owl, ver April 1, 2004</owl:versionInfo>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#AdministrativeStaff">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>administrative staff worker</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Employee"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Article">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>article</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#AssistantProfessor">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>assistant professor</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#AssociateProfessor">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>associate professor</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Book">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>book</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Chair">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>chair</rdfs:label>
+	<owl:intersectionOf rdf:nodeID="node1d7hctiisx1"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx1">
+	<rdf:first rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx1">
+	<rdf:rest rdf:nodeID="node1d7hctiisx3"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx3">
+	<rdf:first rdf:nodeID="node1d7hctiisx2"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx2">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+	<owl:onProperty rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#headOf"/>
+	<owl:someValuesFrom rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Department"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx3">
+	<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Chair">
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#ClericalStaff">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>clerical staff worker</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#AdministrativeStaff"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#College">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>school</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#ConferencePaper">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>conference paper</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Article"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Course">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>teaching course</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Work"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Dean">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>dean</rdfs:label>
+	<owl:intersectionOf rdf:nodeID="node1d7hctiisx5"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx5">
+	<rdf:first rdf:nodeID="node1d7hctiisx4"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx4">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+	<owl:onProperty rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#headOf"/>
+	<owl:someValuesFrom rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#College"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx5">
+	<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Dean">
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Department">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>university department</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Director">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>director</rdfs:label>
+	<owl:intersectionOf rdf:nodeID="node1d7hctiisx6"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx6">
+	<rdf:first rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx6">
+	<rdf:rest rdf:nodeID="node1d7hctiisx8"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx8">
+	<rdf:first rdf:nodeID="node1d7hctiisx7"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx7">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+	<owl:onProperty rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#headOf"/>
+	<owl:someValuesFrom rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Program"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Program">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx8">
+	<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Employee">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>Employee</rdfs:label>
+	<owl:intersectionOf rdf:nodeID="node1d7hctiisx9"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx9">
+	<rdf:first rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx9">
+	<rdf:rest rdf:nodeID="node1d7hctiisx11"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx11">
+	<rdf:first rdf:nodeID="node1d7hctiisx10"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx10">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+	<owl:onProperty rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#worksFor"/>
+	<owl:someValuesFrom rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx11">
+	<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Faculty">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>faculty member</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Employee"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#FullProfessor">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>full professor</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#GraduateCourse">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>Graduate Level Courses</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Course"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#GraduateStudent">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>graduate student</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+	<rdfs:subClassOf rdf:nodeID="node1d7hctiisx12"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx12">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+	<owl:onProperty rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#takesCourse"/>
+	<owl:someValuesFrom rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#GraduateCourse"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#GraduateCourse">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Institute">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>institute</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#JournalArticle">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>journal article</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Article"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Lecturer">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>lecturer</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Faculty"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Manual">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>manual</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>organization</rdfs:label>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>person</rdfs:label>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#PostDoc">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>post doctorate</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Faculty"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>professor</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Faculty"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Program">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>program</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>publication</rdfs:label>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Research">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>research work</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Work"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#ResearchAssistant">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>university research assistant</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+	<rdfs:subClassOf rdf:nodeID="node1d7hctiisx13"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx13">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+	<owl:onProperty rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#worksFor"/>
+	<owl:someValuesFrom rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#ResearchGroup"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#ResearchGroup">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>research group</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Schedule">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>schedule</rdfs:label>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Software">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>software program</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Specification">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>published specification</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Student">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>student</rdfs:label>
+	<owl:intersectionOf rdf:nodeID="node1d7hctiisx14"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx14">
+	<rdf:first rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx14">
+	<rdf:rest rdf:nodeID="node1d7hctiisx16"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx16">
+	<rdf:first rdf:nodeID="node1d7hctiisx15"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx15">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+	<owl:onProperty rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#takesCourse"/>
+	<owl:someValuesFrom rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Course"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Course">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx16">
+	<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#SystemsStaff">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>systems staff worker</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#AdministrativeStaff"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#TeachingAssistant">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>university teaching assistant</rdfs:label>
+	<owl:intersectionOf rdf:nodeID="node1d7hctiisx17"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx17">
+	<rdf:first rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx17">
+	<rdf:rest rdf:nodeID="node1d7hctiisx19"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx19">
+	<rdf:first rdf:nodeID="node1d7hctiisx18"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx18">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+	<owl:onProperty rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#teachingAssistantOf"/>
+	<owl:someValuesFrom rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Course"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Course">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+</rdf:Description>
+
+<rdf:Description rdf:nodeID="node1d7hctiisx19">
+	<rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#TechnicalReport">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>technical report</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Article"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#UndergraduateStudent">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>undergraduate student</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Student"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#University">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>university</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#UnofficialPublication">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>unnoficial publication</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#VisitingProfessor">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>visiting professor</rdfs:label>
+	<rdfs:subClassOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Work">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+	<rdfs:label>Work</rdfs:label>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#advisor">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is being advised by</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#affiliatedOrganizationOf">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is affiliated with</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#affiliateOf">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is affiliated with</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#age">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+	<rdfs:label>is age</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#degreeFrom">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>has a degree from</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#University"/>
+	<owl:inverseOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#hasAlumnus"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#doctoralDegreeFrom">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>has a doctoral degree from</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#University"/>
+	<rdfs:subPropertyOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#degreeFrom"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#emailAddress">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+	<rdfs:label>can be reached at</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#hasAlumnus">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>has as an alumnus</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#University"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+	<owl:inverseOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#degreeFrom"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#headOf">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is the head of</rdfs:label>
+	<rdfs:subPropertyOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#worksFor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#listedCourse">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>lists as a course</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Schedule"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Course"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#mastersDegreeFrom">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>has a masters degree from</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#University"/>
+	<rdfs:subPropertyOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#degreeFrom"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#member">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>has as a member</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#memberOf">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>member of</rdfs:label>
+	<owl:inverseOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#member"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#name">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+	<rdfs:label>name</rdfs:label>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#officeNumber">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+	<rdfs:label>office room No.</rdfs:label>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#orgPublication">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>publishes</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#publicationAuthor">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>was written by</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#publicationDate">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>was written on</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#publicationResearch">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is about</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Research"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#researchInterest">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+	<rdfs:label>is researching</rdfs:label>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#researchProject">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>has as a research project</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#ResearchGroup"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Research"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#softwareDocumentation">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is documented in</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Software"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Publication"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#softwareVersion">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is version</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Software"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#subOrganizationOf">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+	<rdfs:label>is part of</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Organization"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#takesCourse">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is taking</rdfs:label>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#teacherOf">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>teaches</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Faculty"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Course"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#teachingAssistantOf">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is a teaching assistant for</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#TeachingAssistant"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Course"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#telephone">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+	<rdfs:label>telephone number</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#tenured">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>is tenured:</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Professor"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#title">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+	<rdfs:label>title</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#undergraduateDegreeFrom">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>has an undergraduate degree from</rdfs:label>
+	<rdfs:domain rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+	<rdfs:range rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#University"/>
+	<rdfs:subPropertyOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#degreeFrom"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#worksFor">
+	<rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+	<rdfs:label>Works For</rdfs:label>
+	<rdfs:subPropertyOf rdf:resource="http://swat.cse.lehigh.edu/onto/univ-bench.owl#memberOf"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
@@ -6,11 +6,9 @@ import org.apache.hadoop.mapred.JobConf
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.SparkContext
 import org.semanticweb.owlapi.model.OWLAxiom
+
 import net.sansa_stack.owl.common.parsing.{RDFXMLSyntaxParsing, RDFXMLSyntaxPrefixParsing}
-
-
 
 class RDFXMLSyntaxOWLExpressionsRDDBuilder extends Serializable with RDFXMLSyntaxPrefixParsing with RDFXMLSyntaxParsing {
 
@@ -84,15 +82,6 @@ class RDFXMLSyntaxOWLExpressionsRDDBuilder extends Serializable with RDFXMLSynta
     val OWLAxiomsRDD: RDD[OWLAxiom] = OWLAxiomsList.flatMap(line => line.iterator().asScala)
                         .distinct()
 
-//    val builder = new RDFXMLSyntaxExpressionBuilder(prefixesMap)
-//
-//    OWLAxiomsRDD.map(x => builder.clean(x.toString)).filter(_ != null)
-
-
-//    println("Axioms are : \n")
-//    OWLAxiomsRDD.foreach(println(_))
-//    println("Axioms count = " + OWLAxiomsRDD.count())
-
     val refinedRDD = refineOWLAxioms (spark.sparkContext, OWLAxiomsRDD)
     println("Axioms count = " + refinedRDD.count())
 
@@ -116,13 +105,8 @@ object RDFXMLSyntaxOWLExpressionsRDDBuilder {
       .appName("RDF/XML Parser")
       .getOrCreate()
 
- //   Logger.getLogger("org").setLevel(Level.OFF)
     Logger.getLogger("akka").setLevel(Level.OFF)
     Logger.getLogger(this.getClass).setLevel(Level.ERROR)
-
- //   val sc: SparkContext = sparkSession.sparkContext
-
-  //  sparkSession.sparkContext.setLogLevel("ALL")
 
     val RDFXMLBuilder = new RDFXMLSyntaxOWLExpressionsRDDBuilder
     val rdd = RDFXMLBuilder.build(sparkSession, input)

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
@@ -1,20 +1,24 @@
 package net.sansa_stack.owl.spark.rdd
 
-import collection.JavaConverters._
+import scala.collection.JavaConverters._
+
+import com.typesafe.scalalogging.{Logger => ScalaLogger}
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.mapred.JobConf
-import org.apache.log4j.{Level, Logger}
+import org.apache.log4j.{Level, Logger => Log4JLogger}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.semanticweb.owlapi.model.OWLAxiom
 
 import net.sansa_stack.owl.common.parsing.{RDFXMLSyntaxParsing, RDFXMLSyntaxPrefixParsing}
 
+
 class RDFXMLSyntaxOWLExpressionsRDDBuilder extends Serializable with RDFXMLSyntaxPrefixParsing with RDFXMLSyntaxParsing {
+  private val logger = ScalaLogger(this.getClass)
 
   /**
-    * Builds a snippet conforming to the RDFXML syntax which then can
-    * be parsed by the OWLAPI RDFXML syntax parser.
+    * Builds a snippet conforming to the RDF/XML syntax which then can
+    * be parsed by the OWL API RDF/XML syntax parser.
     * A single expression, e.g.
     *
     * <rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person">
@@ -33,8 +37,6 @@ class RDFXMLSyntaxOWLExpressionsRDDBuilder extends Serializable with RDFXMLSynta
     * @param filePath the path to the input file
     * @return The set of axioms corresponding to the expression.
     */
-
-
   def build(spark: SparkSession, filePath: String): OWLAxiomsRDD = {
 
     val conf = new JobConf()
@@ -51,53 +53,50 @@ class RDFXMLSyntaxOWLExpressionsRDDBuilder extends Serializable with RDFXMLSynta
     org.apache.hadoop.mapred.FileInputFormat.addInputPaths(conf, filePath)
     org.apache.hadoop.mapred.FileInputFormat.addInputPaths(prefixes, filePath)
 
-    // RDF XML Record
-    // read data and save in RDD as block- RDFXML Record
-    val RDFXML_Record: RDD[(Text, Text)] = spark.sparkContext.hadoopRDD(conf,
+    // RDF/XML Record
+    // read data and save in RDD as block-RDF/XML Record
+    val rdfXMLRecord: RDD[(Text, Text)] = spark.sparkContext.hadoopRDD(conf,
       classOf[org.apache.hadoop.streaming.StreamInputFormat],
       classOf[org.apache.hadoop.io.Text],
       classOf[org.apache.hadoop.io.Text])
 
-    // Convert the block- RDFXML Record to String DataType
-    val rawRDD: RDD[String] = RDFXML_Record.map { case (x, y) => (x.toString()) }
+    // Convert the block-RDF/XML record to String
+    val rawRDD: RDD[String] = rdfXMLRecord.map { case (x, _) => x.toString }
 
-    // RDF XML Prefixes
-    // read data and save in RDD as block- RDFXML Prefixes
-    val RDFXML_Prefixes = spark.sparkContext.hadoopRDD(prefixes,
+    // RDF/XML prefixes
+    // Read data and save in RDD as block-RDF/XML prefixes
+    val rdfXMLPrefixes = spark.sparkContext.hadoopRDD(prefixes,
       classOf[org.apache.hadoop.streaming.StreamInputFormat],
       classOf[org.apache.hadoop.io.Text],
       classOf[org.apache.hadoop.io.Text])
 
-    // Convert the block- RDFXML Prefixes to String DataType
-    var tmp_Prefixes = RDFXML_Prefixes.map { case (x, y) => (x.toString()) }.distinct()
+    // Convert the block-RDF/XML prefixes to String
+    val tmpPrefixes = rdfXMLPrefixes.map { case (x, _) => x.toString }.distinct()
+    val prefixesString: String = tmpPrefixes.reduce((a, b) => a + "\n" + b)
 
-    val pref: String = tmp_Prefixes.reduce((a, b) => a + "\n" + b)
+    val owlAxioms: RDD[OWLAxiom] =
+      rawRDD.map(record => parseRecord(record, prefixesString))
+        .filter(x => !x.isEmpty)
+        .flatMap(axioms => axioms.asScala)
+        .distinct()
 
-//    val tmp: Array[(String, String)] = rawRDD.filter(isPrefix(_)).map(parsePrefix).collect()
-//    val prefixesMap: Map[String, String] = tmp.toMap
-
-    val OWLAxiomsList = rawRDD.map(record => RecordParse(record, pref))
-                              .filter(x => !x.isEmpty)
-
-    val OWLAxiomsRDD: RDD[OWLAxiom] = OWLAxiomsList.flatMap(line => line.iterator().asScala)
-                        .distinct()
-
-    val refinedRDD = refineOWLAxioms (spark.sparkContext, OWLAxiomsRDD)
-    println("Axioms count = " + refinedRDD.count())
+    val refinedRDD = refineOWLAxioms(spark.sparkContext, owlAxioms)
+//    logger.debug(s"Axioms count = ${refinedRDD.count()}")
 
     refinedRDD
   }
 }
 
 object RDFXMLSyntaxOWLExpressionsRDDBuilder {
+  private val logger = ScalaLogger(this.getClass)
 
   def main(args: Array[String]): Unit = {
 
     val input: String = getClass.getResource("/univ-bench.rdf").getPath
 
-    println("================================")
-    println("|        RDF/XML Parser        |")
-    println("================================")
+    logger.info("================================")
+    logger.info("|        RDF/XML Parser        |")
+    logger.info("================================")
 
     @transient val sparkSession = SparkSession.builder
       .master("local[*]")
@@ -105,15 +104,13 @@ object RDFXMLSyntaxOWLExpressionsRDDBuilder {
       .appName("RDF/XML Parser")
       .getOrCreate()
 
-    Logger.getLogger("akka").setLevel(Level.OFF)
-    Logger.getLogger(this.getClass).setLevel(Level.ERROR)
+    Log4JLogger.getLogger("akka").setLevel(Level.OFF)
+    Log4JLogger.getLogger(this.getClass).setLevel(Level.ERROR)
 
     val RDFXMLBuilder = new RDFXMLSyntaxOWLExpressionsRDDBuilder
-    val rdd = RDFXMLBuilder.build(sparkSession, input)
+    val rdd: OWLAxiomsRDD = RDFXMLBuilder.build(sparkSession, input)
+    rdd.foreach(axiom => logger.info(axiom.toString))
 
     sparkSession.stop
   }
 }
-
-
-

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
@@ -8,7 +8,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.SparkContext
 import org.semanticweb.owlapi.model.OWLAxiom
-
 import net.sansa_stack.owl.common.parsing.{RDFXMLSyntaxParsing, RDFXMLSyntaxPrefixParsing}
 
 
@@ -76,18 +75,28 @@ class RDFXMLSyntaxOWLExpressionsRDDBuilder extends Serializable with RDFXMLSynta
 
     val pref: String = tmp_Prefixes.reduce((a, b) => a + "\n" + b)
 
+//    val tmp: Array[(String, String)] = rawRDD.filter(isPrefix(_)).map(parsePrefix).collect()
+//    val prefixesMap: Map[String, String] = tmp.toMap
+
     val OWLAxiomsList = rawRDD.map(record => RecordParse(record, pref))
                               .filter(x => !x.isEmpty)
 
     val OWLAxiomsRDD: RDD[OWLAxiom] = OWLAxiomsList.flatMap(line => line.iterator().asScala)
                         .distinct()
 
-    println("Axioms are : \n")
-    OWLAxiomsRDD.foreach(println(_))
+//    val builder = new RDFXMLSyntaxExpressionBuilder(prefixesMap)
+//
+//    OWLAxiomsRDD.map(x => builder.clean(x.toString)).filter(_ != null)
 
-    println("Axioms count = " + OWLAxiomsRDD.count())
 
-    OWLAxiomsRDD
+//    println("Axioms are : \n")
+//    OWLAxiomsRDD.foreach(println(_))
+//    println("Axioms count = " + OWLAxiomsRDD.count())
+
+    val refinedRDD = refineOWLAxioms (spark.sparkContext, OWLAxiomsRDD)
+    println("Axioms count = " + refinedRDD.count())
+
+    refinedRDD
   }
 }
 
@@ -109,10 +118,11 @@ object RDFXMLSyntaxOWLExpressionsRDDBuilder {
 
  //   Logger.getLogger("org").setLevel(Level.OFF)
     Logger.getLogger("akka").setLevel(Level.OFF)
+    Logger.getLogger(this.getClass).setLevel(Level.ERROR)
 
-    val sc: SparkContext = sparkSession.sparkContext
+ //   val sc: SparkContext = sparkSession.sparkContext
 
-    sparkSession.sparkContext.setLogLevel("ALL")
+  //  sparkSession.sparkContext.setLogLevel("ALL")
 
     val RDFXMLBuilder = new RDFXMLSyntaxOWLExpressionsRDDBuilder
     val rdd = RDFXMLBuilder.build(sparkSession, input)

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
@@ -1,0 +1,132 @@
+package net.sansa_stack.owl.spark.rdd
+
+import collection.JavaConverters._
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.mapred.JobConf
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.SparkContext
+import org.semanticweb.owlapi.model.OWLAxiom
+
+import net.sansa_stack.owl.common.parsing.{RDFXMLSyntaxParsing, RDFXMLSyntaxPrefixParsing}
+
+
+
+class RDFXMLSyntaxOWLExpressionsRDDBuilder extends Serializable with RDFXMLSyntaxPrefixParsing with RDFXMLSyntaxParsing {
+
+  /**
+    * Builds a snippet conforming to the RDFXML syntax which then can
+    * be parsed by the OWLAPI RDFXML syntax parser.
+    * A single expression, e.g.
+    *
+    * <rdf:Description rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person">
+    * <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    * </rdf:Description>
+    *
+    * has thus to be wrapped into a ontology description as follows
+    *
+    * <rdf:RDF
+    * xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    * xmlns:owl="http://www.w3.org/2002/07/owl#">
+    * <owl:Class rdf:about="http://swat.cse.lehigh.edu/onto/univ-bench.owl#Person"/>
+    * </rdf:RDF>
+    *
+    * @param spark SparkSession
+    * @param filePath the path to the input file
+    * @return The set of axioms corresponding to the expression.
+    */
+
+
+  def build(spark: SparkSession, filePath: String): OWLAxiomsRDD = {
+
+    val conf = new JobConf()
+    val prefixes = new JobConf()
+
+    conf.set("stream.recordreader.class", "org.apache.hadoop.streaming.StreamXmlRecordReader")
+    conf.set("stream.recordreader.begin", "<rdf:Description") // start Tag
+    conf.set("stream.recordreader.end", "</rdf:Description>") // End Tag
+
+    prefixes.set("stream.recordreader.class", "org.apache.hadoop.streaming.StreamXmlRecordReader")
+    prefixes.set("stream.recordreader.begin", "<rdf:RDF") // start Tag
+    prefixes.set("stream.recordreader.end", ">") // End Tag
+
+    org.apache.hadoop.mapred.FileInputFormat.addInputPaths(conf, filePath)
+    org.apache.hadoop.mapred.FileInputFormat.addInputPaths(prefixes, filePath)
+
+    // RDF XML Record
+    // read data and save in RDD as block- RDFXML Record
+    val RDFXML_Record: RDD[(Text, Text)] = spark.sparkContext.hadoopRDD(conf,
+      classOf[org.apache.hadoop.streaming.StreamInputFormat],
+      classOf[org.apache.hadoop.io.Text],
+      classOf[org.apache.hadoop.io.Text])
+
+    // Convert the block- RDFXML Record to String DataType
+    val rawRDD: RDD[String] = RDFXML_Record.map { case (x, y) => (x.toString()) }
+
+    // RDF XML Prefixes
+    // read data and save in RDD as block- RDFXML Prefixes
+    val RDFXML_Prefixes = spark.sparkContext.hadoopRDD(prefixes,
+      classOf[org.apache.hadoop.streaming.StreamInputFormat],
+      classOf[org.apache.hadoop.io.Text],
+      classOf[org.apache.hadoop.io.Text])
+
+    // Convert the block- RDFXML Prefixes to String DataType
+    var tmp_Prefixes = RDFXML_Prefixes.map { case (x, y) => (x.toString()) }.distinct()
+
+    val pref: String = tmp_Prefixes.reduce((a, b) => a + "\n" + b)
+
+//    val tmp: Array[(String, String)] = rawRDD.filter(isPrefix(_)).map(parsePrefix).collect()
+//    val prefixesMap: Map[String, String] = tmp.toMap
+
+    val OWLAxiomsList = rawRDD.map(record => RecordParse(record, pref))
+                              .filter(x => !x.isEmpty)
+
+    val OWLAxiomsRDD: RDD[OWLAxiom] = OWLAxiomsList.flatMap(line => line.iterator().asScala)
+                        .distinct()
+
+//    val builder = new RDFXMLSyntaxExpressionBuilder(prefixesMap)
+//
+//    OWLAxiomsRDD.map(x => builder.clean(x.toString)).filter(_ != null)
+
+
+    println("Axioms are : \n")
+    OWLAxiomsRDD.foreach(println(_))
+    println("Axioms count = " + OWLAxiomsRDD.count())
+
+    OWLAxiomsRDD
+  }
+}
+
+object RDFXMLSyntaxOWLExpressionsRDDBuilder {
+
+  def main(args: Array[String]): Unit = {
+
+    val input: String = getClass.getResource("/univ-bench.rdf").getPath
+
+    println("================================")
+    println("|        RDF/XML Parser        |")
+    println("================================")
+
+    @transient val sparkSession = SparkSession.builder
+      .master("local[*]")
+      .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .appName("RDF/XML Parser")
+      .getOrCreate()
+
+ //   Logger.getLogger("org").setLevel(Level.OFF)
+    Logger.getLogger("akka").setLevel(Level.OFF)
+
+    val sc: SparkContext = sparkSession.sparkContext
+
+    sparkSession.sparkContext.setLogLevel("ALL")
+
+    val RDFXMLBuilder = new RDFXMLSyntaxOWLExpressionsRDDBuilder
+    val rdd = RDFXMLBuilder.build(sparkSession, input)
+
+    sparkSession.stop
+  }
+}
+
+
+

--- a/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
+++ b/sansa-owl-spark/src/main/scala/net/sansa_stack/owl/spark/rdd/RDFXMLSyntaxOWLExpressionsRDDBuilder.scala
@@ -76,22 +76,15 @@ class RDFXMLSyntaxOWLExpressionsRDDBuilder extends Serializable with RDFXMLSynta
 
     val pref: String = tmp_Prefixes.reduce((a, b) => a + "\n" + b)
 
-//    val tmp: Array[(String, String)] = rawRDD.filter(isPrefix(_)).map(parsePrefix).collect()
-//    val prefixesMap: Map[String, String] = tmp.toMap
-
     val OWLAxiomsList = rawRDD.map(record => RecordParse(record, pref))
                               .filter(x => !x.isEmpty)
 
     val OWLAxiomsRDD: RDD[OWLAxiom] = OWLAxiomsList.flatMap(line => line.iterator().asScala)
                         .distinct()
 
-//    val builder = new RDFXMLSyntaxExpressionBuilder(prefixesMap)
-//
-//    OWLAxiomsRDD.map(x => builder.clean(x.toString)).filter(_ != null)
-
-
     println("Axioms are : \n")
     OWLAxiomsRDD.foreach(println(_))
+
     println("Axioms count = " + OWLAxiomsRDD.count())
 
     OWLAxiomsRDD


### PR DESCRIPTION
Hi Patrick, could you please check the unexpected results we discussed before such as:

- every `rdfs:domain` is converted to `AnnotationPropertyDomain` instead of `DataPropertyDomain` or `ObjectPropertyDomain`.
- every `rdfs:subPropertyOf` is converted to `SubAnnotationPropertyOf` instead of `SubObjectPropertyOf`
- get the error “`Unparsed triple`” when having restrictions such as someValuesFrom, because it uses blank nodes, and I have no axioms for that.